### PR TITLE
Set status keyword in HttpResponse object

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -52,7 +52,7 @@ async def confidence_indicator(request):
             async with session.post(
                 USPS_URL, data=request.body, ssl=sslcontext
             ) as response:
-                return HttpResponse(await response.read(), response.status)
+                return HttpResponse(await response.read(), status=response.status)
     except ClientError as error:
         logging.error("Aiohttp error: %s", error)
         return JsonResponse({"error": "ClientError while validating address"})


### PR DESCRIPTION
Correct bug in response status code caused by positional argument
being used instead of keyword arguement. 