### PR TITLE
Feature/swagger redoc integration

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -8,8 +8,8 @@ class ConfidenceIndicatorRequestSerializer(serializers.Serializer):
     uid = serializers.UUIDField()
     first_name = serializers.CharField()
     last_name = serializers.CharField()
-    middle_name = serializers.CharField()
-    suffix = serializers.CharField()
+    middle_name = serializers.CharField(required=False)
+    suffix = serializers.CharField(required=False)
     delivery_address = serializers.CharField()
     address_city_state_zip = serializers.CharField()
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,21 @@
+""" Serializers for Generating Swagger Documentation """
+from rest_framework import serializers
+
+
+class ConfidenceIndicatorRequestSerializer(serializers.Serializer):
+    """ Serializer for Confidence Indicator Requests """
+
+    uid = serializers.UUIDField()
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
+    middle_name = serializers.CharField()
+    suffix = serializers.CharField()
+    delivery_address = serializers.CharField()
+    address_city_state_zip = serializers.CharField()
+
+
+class ConfidenceIndicatorResponseSerializer(serializers.Serializer):
+    """ Serializer for Confidence Indicator Responses """
+
+    uid = serializers.UUIDField()
+    indicator = serializers.CharField()

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,44 @@
 """ USPS API app url definitions """
 from django.urls import path
 from api import views
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status
+from drf_yasg import openapi
+from .serializers import (
+    ConfidenceIndicatorRequestSerializer,
+    ConfidenceIndicatorResponseSerializer,
+)
+
+decorated_confidence_indicator_view = swagger_auto_schema(
+    method="post",
+    request_body=ConfidenceIndicatorRequestSerializer,
+    responses={
+        status.HTTP_200_OK: ConfidenceIndicatorResponseSerializer,
+        status.HTTP_400_BAD_REQUEST: openapi.Response(
+            description="Missing Fields",
+            examples={
+                "application/json": {
+                    "uid": "90c0a824-d5f6-4e18-8420-efd7464f436a",
+                    "error": "Mandatory field(s) missing (first_name, last_name)",
+                },
+            },
+        ),
+        status.HTTP_500_INTERNAL_SERVER_ERROR: openapi.Response(
+            description="Internal Server Error",
+            examples={
+                "application/json": {
+                    "uid": "90c0a824-d5f6-4e18-8420-efd7464f436a",
+                    "error": "Internal Server error",
+                }
+            },
+        ),
+    },
+)(views.confidence_indicator)
 
 urlpatterns = [
     path(
-        "confidenceindicator", views.confidence_indicator, name="confidence_indicator"
+        "confidenceindicator",
+        decorated_confidence_indicator_view,
+        name="confidence_indicator",
     ),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -10,7 +10,8 @@ from django.http import JsonResponse, HttpResponse
 from google.oauth2 import service_account
 from google.auth.transport.requests import Request
 from api import transaction_log
-
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import api_view
 
 USPS_UUID = "5738f577-d283-49ec-9695-32b106c049d8"
 USPS_URL = "https://cat-aii.usps.gov/"
@@ -25,6 +26,7 @@ if not settings.DEBUG:
     sslcontext = ssl.create_default_context(cafile="cat-aii-root.cer")
 
 
+@api_view(["POST"])
 async def confidence_indicator(request):
     """ USPS AII API view """
     if settings.DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ daphne ~= 3.0
 twisted[tls, http2]
 google-auth
 requests
+drf_yasg == 1.20.0
+whitenoise == 5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-auth
 requests
 drf_yasg == 1.20.0
 whitenoise == 5.2.0
+djangorestframework ~= 3.12

--- a/usps/settings.py
+++ b/usps/settings.py
@@ -17,6 +17,13 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # DEBUG set is set to True if env var is "True"
 DEBUG = os.environ.get("DEBUG", "False") == "True"
 
+# Static file settings
+STATIC_URL = "/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, "usps/static")
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+
+
 # Deployment-specific settings
 if not DEBUG:
     USPS_SERVICE_INFO = os.environ.get("USPS_SERVICE_INFO")
@@ -46,6 +53,8 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "api.apps.ApiConfig",
+    "django.contrib.staticfiles",
+    "drf_yasg",
 ]
 
 MIDDLEWARE = [
@@ -54,6 +63,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
 
 ROOT_URLCONF = "usps.urls"

--- a/usps/settings.py
+++ b/usps/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "api.apps.ApiConfig",
     "django.contrib.staticfiles",
+    "rest_framework",
     "drf_yasg",
 ]
 

--- a/usps/urls.py
+++ b/usps/urls.py
@@ -1,4 +1,31 @@
 """ USPS Project URL definitions """
-from django.urls import include, path
+from django.urls import include, path, re_path
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
-urlpatterns = [path("", include("api.urls"))]
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="USPS Microservice",
+        default_version="v0.1",
+    ),
+    public=True,
+)
+
+urlpatterns = [
+    path("", include("api.urls")),
+    # path to download json or yaml open api spec file
+    re_path(
+        r"^doc(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    # path to swagger documentation
+    path(
+        "doc/",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    # path to swagger with redoc
+    path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+]


### PR DESCRIPTION
Integrate OpenAPI/swagger file generation and add swagger/redoc viewing options. The Django Rest Framework must be used for swagger integration. No functionality of the existing endpoint has been changed except for a DRF decorator that allows for swagger schema generation to occur.