### PR TITLE
bugfix/pin dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: stable
     hooks:
       - id: black
         language_version: python3.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 pre-commit
-black
+git+git://github.com/psf/black@stable
 pylint
-bandit
+bandit 


### PR DESCRIPTION
Ensure users are installing/checking commits with the version of Black that will be used to lint their pull requests.